### PR TITLE
Fix branch pattern in Jenkinsfile

### DIFF
--- a/olm/jenkins/ci/Jenkinsfile
+++ b/olm/jenkins/ci/Jenkinsfile
@@ -5,7 +5,7 @@ String version = '1.1.0'
 String imgTag  = "v" + version + "-1"
 
 olcnePipeline(
-        branchPattern: new BranchPattern(master: 'oracle/release/.*', feature: '(?!^release/.*$)(^.*$)'),
+        branchPattern: new BranchPattern(master: '(master|release/.*)', feature: '(?!^master$)(?!^release/.*$)(^.*$)'),
         containers: [('container-registry.oracle.com/olcne/cert-manager-webhook-oci:' + imgTag): 'olcne/cert-manager-webhook-oci:' + imgTag],
         platforms: ['ol8'],
         architectures: ['x86_64', 'aarch64'],


### PR DESCRIPTION
# Description

In Jenkinsfile, release branch pattern should be release/.* not oracle/release/.*

Fixes # (https://github.com/oracle-cne/cert-manager-webhook-oci/issues/4)

## Container Images

- container-registry.oracle.com/olcne/cert-manager-webhook-oci:v1.1.0-1
